### PR TITLE
Change atomic entities for VL approach

### DIFF
--- a/client/types/types_jorge.atd
+++ b/client/types/types_jorge.atd
@@ -1,0 +1,266 @@
+
+
+type json <ocaml module="Abs_json"> = abstract
+(* Atomit Entity Manifest *)
+type atomic_entity = {
+  uuid : string;
+  name : string;
+  atomic_type <json name="type">: string;
+  version : int;
+  entity_data : json;  (* this should be a JSON *)
+  ?status: string option;
+  ?constraints : constraints_type option;
+  ?dst : string option;
+  ?error : string option;
+}
+type constraints_type = {
+  ?i_o <json name="i/o"> : constraint_type list option;
+  ?networks : constraint_type list option;
+  ?accelerators : constraint_type list option;
+  ?arch_constraint <json name="arch"> : string option;
+  ?os_constraint <json name="os">: string option;
+  ?position : position_constraint_type option;
+}
+
+type constraint_type = {
+  constratint_type <json name="type"> : string;
+  number : int;
+}
+
+type position_constraint_type = {
+  lat : string;
+  lon : string;
+  radius : int;
+
+}
+
+(* Entity Manifest *)
+type entity = {
+  uuid : string;
+  name : string;
+  version : int;
+  entity_type <json name="type"> : string;
+  components : component_type list;
+  ?status : string option;
+  ?description : string option;
+  ?networks : network list option;
+}
+
+type component_type = {
+  name : string;
+  manifest : atomic_entity;
+  ?node : string option;
+  need : string list;
+  ?proximity : string option;
+
+}
+
+(* Network Manifest *)
+type network = {
+  uuid : string;
+  name : string;
+  network_type : string;
+  ?status : string option;
+  ?virtual_device : string option;
+  ?ip_range : string option;
+  ?ip_type : string option;
+  ?gateway : string option;
+  ?dns : string option;
+  ?multicast_address : string option;
+  ?dhcp_range : string option;
+  ?interfaces : string list option;
+  ?vxlan_id : int option;
+  ?vxlan_dev : string option;
+  ?has_dhcp : bool option;
+
+}
+
+(* Plugin manifest *)
+type plugin = {
+  uuid : string;
+  name : string;
+  version : int;
+  plugin_type <json name="type"> : string;
+  ?status : string option;
+  ?requirements : string list option;
+  ?description : string option;
+  ?url : string option;
+  ?configuration : string option;
+}
+
+
+(* VM/CONTAINERS FLAVOR AND IMAGES *)
+
+type image = {
+  uuid : string;
+  name : string;
+  base_image :  string;
+  ?format : string option;
+  ?path : string option;
+  ?status : string option;
+}
+
+type flavor = {
+  uuid : string;
+  name : string;
+  ?cpu_flavor <json name="cpu"> : int option;
+  ?memory_flavor <json name="memory"> : int option;
+  ?disk_size_flavor <json name="disk_size"> : int option;
+  ?status : string option;
+}
+
+
+(* NODE INFORMATION *)
+type node_info = {
+  uuid : string;
+  name : string;
+  os : string;
+  cpu : cpu_spec_type list;
+  ram : ram_spec_type;
+  disks : disks_spec_type list;
+  io : io_spec_type list;
+  accelerator : accelerator_spec_type list;
+  network : network_spec_type list;
+  ?position : pos_spec_type option;
+}
+
+
+type cpu_spec_type = {
+  model : string;
+  frequency : float;
+  arch : string;
+}
+
+
+type ram_spec_type = {
+  size : float;
+}
+
+type disks_spec_type = {
+  local_address : string;
+  dimension : float;
+  mount_point : string;
+  filesystem : string;
+}
+
+type io_spec_type = {
+  name : string;
+  io_type : string;
+  io_file : string;
+  available : bool;
+}
+
+type accelerator_spec_type = {
+
+  hw_address : string;
+  name : string;
+  supported_library : string list;
+  available : bool;
+
+}
+
+type network_spec_type = {
+  intf_name : string;
+  intf_mac_address : string;
+  intf_speed : int;
+  intf_type <json name="type"> : string;
+  available : bool;
+  default_gw : bool;
+  intf_configuration <json name="inft_configuration"> : intf_conf_type;
+}
+
+type intf_conf_type = {
+  ipv4_address : string;
+  ipv4_netmask : string;
+  ipv4_gateway : string;
+  ipv6_address : string;
+  ipv6_netmask : string;
+  ?ipv6_gateway : string option;
+  ?bus_address : string option;
+
+}
+
+type pos_spec_type = {
+  lat : float;
+  lon : float;
+}
+
+
+(* PLUGINS INFO*)
+
+type plugins_info_type = {
+  plugins : plugin list;
+}
+
+
+
+(* Atomic Entity Types *)
+
+type atomic_entity_connection_point = {
+  connection_point_uuid : string;
+  addresses : address_info list;
+  ?intf_name : string option;
+  ?br_name : string option;
+  ?intf_type <json name="type"> : string option;
+  ?is_sap : bool;
+  ?virtual_links: vl_atomic_entity list option;
+}
+
+type address_info = {
+  address_info_uuid : string;
+  mac_address : string;
+  ipv4_address : string;
+  ipv4_netmask : string;
+  ipv4_gateway : string;
+  ipv6_address : string;
+  ipv6_netmask : string;
+  ?ipv6_gateway : string option;
+  ?bus_address : string option;
+}
+
+type vl_atomic_entity = {
+  vl_uuid : string;
+  protocol : string;
+  flow_pattern : string;
+  description : string;
+  vl_qos : vl_qos;
+}
+
+type vl_qos = {
+  vl_qos_uuid : string;
+  bitrate : int;
+  latency : int;
+  packet_delay_variation : float;
+  packet_loss_ratio : int;
+  priority : int;
+}
+
+type vm_atomic_entity = {
+  name : string;
+  uuid : string;
+  ?flavor_id : string option;
+  ?cpu : int option;
+  ?memory : int option;
+  ?disk_size : int option;
+  base_image : string;
+  ?user_data <json name="user-data"> : string option;
+  ?ssk_key <json name="ssk-key">: string option;
+  ?connection_point : atomic_entity_connection_point list option;
+}
+
+type container_atomic_entity = {
+  name : string;
+  uuid : string;
+  base_image : string;
+  ?user_data <json name="user-data"> : string option;
+  ?ssk_key <json name="ssk-key">: string option;
+  ?connection_point : atomic_entity_connection_point list option;
+}
+
+type na_atomic_entity = {
+  name : string;
+  uuid : string;
+  command : string;
+  ?source : string option;
+  ?args : string list option;
+}


### PR DESCRIPTION
With this commit I follow the ETSI NFV approach to include VLs.
We include this:
 * CPDs as atomic entities referenced by containers/vms
 * VLs referenced by CPDs (previously it was the other way arround)
 * QoS for the VL (bitrate, latency, packet loss, etc.)
 * The atomic CPDs have addresses specification
 * A CPD can be specified as SAP

There is something to be discussed: should we reference the network types from the CPDs.
IMHO we should, since ip addresses specified in the CPDs will match the subnets specified in the network entity.