### PR TITLE
Allow CPDs reference multiple networks

### DIFF
--- a/client/types/types.atd
+++ b/client/types/types.atd
@@ -212,7 +212,7 @@ type atomic_entity_connection_point = {
   ?intf_type <json name="type"> : string option;
   ?is_sap : bool;
   ?virtual_links: vl_atomic_entity list option;
-  ?network_uuid : string option;
+  ?network_uuids : string list option;
 }
 
 type address_info = {


### PR DESCRIPTION
This is just a small detail.

We should allow a CPD referencing more than one network because we allow referencing multiple VLs as well.

I'd like to move this information to the VL, since the idea is that each of the VLs attached to the CPD will be inside different networks. That way we keep coherence between VLs and networks.