### PR TITLE
Add MEC oriented fields

### DIFF
--- a/client/types/types.atd
+++ b/client/types/types.atd
@@ -21,6 +21,7 @@ type constraints_type = {
   ?position : position_constraint_type option;
   ?cpu_constraint : cpu_constraint_type option;
   ?running_time_constraint : running_time_constraints_type option;
+  ?migration: migration_constraint_type option;
 }
 
 type constraint_type = {
@@ -32,6 +33,11 @@ type position_constraint_type = {
   lat : string;
   lon : string;
   radius : int;
+}
+
+type migration_constraint_type = {
+  kill_before: bool; (* true=can kill VNF before it has been copied *)
+  script: string; (* Migration script to execute *)
 }
 
 type cpu_constraint_type = {
@@ -55,6 +61,16 @@ type entity = {
   ?status : string option;
   ?description : string option;
   ?networks : network list option;
+  dependencies: dependency_type list;
+}
+
+type dependency_type = {
+  name : string;
+  category : string;
+  version : string;
+  transport_dependency : transport_descriptor; (* Point to mec_app_definition transport_descriptor? *)
+  requested_permissions: string list;
+>>>>>>>>>> TODO: REFERENCE HERE app, entity, service, what? <<<<<<<<<<<
 }
 
 type component_type = {
@@ -63,9 +79,16 @@ type component_type = {
   ?node : string option;
   need : string list;
   ?proximity : string option;
-
+  dns: dns_type option;
 }
 
+type dns_type = {
+  id : string;
+  domainName : string;
+  ipAddressType : string; (* IPv4 or IPv6 *)
+  ipAddress : string;
+  TTL : int;
+}
 
 
 (* Plugin manifest *)

--- a/fog05/json_objects/mec_app_definition.schema
+++ b/fog05/json_objects/mec_app_definition.schema
@@ -1,0 +1,84 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "title": "Generic Definition",
+  "description": "MEC application definition schema",
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "desciption": "describe the action, so the desidered lifecycle state"
+    },
+    "name": {
+      "type": "string"
+    },
+    "export": {
+      "type": "bool"
+    }
+    "uuid": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "service_description": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "transports-supported": {
+            "type": "transport_description"
+          },
+          "serializers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "version": {
+            "type": "string"
+          }
+        }
+    }
+    "transport_description": {
+        "type": "object",
+        "properties": {
+          "protocol": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "security": {
+            "type": "string"
+          }
+        }
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "need": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "proximity": {
+            "type": "object"
+          },
+          "manifest": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# What's been added:
 * add migration_constraint
 * add DNS info for each component
 * add mec_app_definition.schema
 * add dependency constraint for entity

------------------------
# To discuss:
 * should we add something like a "permissions_type" in the dependency inside an entity?
 * the "export" field is only included in the mec_app_definition.schema, but can an entity export a service to the EFS service platform?
 * inside the dependency_type what can we reference, an entity, an app, or both?
 * can we create a "transport_description" field that can be referenced from both a mec_app_descriptor and an entity->dependency_type?