### PR TITLE
Refine MEC-like parameters

### DIFF
--- a/client/types/types.atd
+++ b/client/types/types.atd
@@ -55,7 +55,8 @@ type running_time_constraints_type = {
 type entity = {
   uuid : string;
   name : string;
-  version : int;
+  export: bool; (* If entity service is exported to EFS service platform *)
+  ?export_info : service_info_type option;
   entity_type <json name="type"> : string;
   components : component_type list;
   ?status : string option;
@@ -65,12 +66,36 @@ type entity = {
 }
 
 type dependency_type = {
-  name : string;
+  target_uuid : string; (* uuid of the entity or mec_application *)
+  target_info : service_info_type;
+  requested_permissions : permission_type list;
+}
+
+type service_info_type = {
+  service_name : string;
   category : string;
   version : string;
-  transport_dependency : transport_descriptor; (* Point to mec_app_definition transport_descriptor? *)
-  requested_permissions: string list;
->>>>>>>>>> TODO: REFERENCE HERE app, entity, service, what? <<<<<<<<<<<
+  transport : transport_descriptor_type; 
+  api_calls : api_type list;
+}
+
+type transport_description_type = {
+  protocol : string;
+  version : string;
+  security : string;
+  endpoint : string;
+  serializers : string list; (* "JSON", "XML", "protobuf3" *)
+}
+
+type permission_type = {
+  api_uuid : string; (* references an api_type *)
+  requested_operations : string list;
+}
+
+type api_type = {
+  uuid : string;
+  URI : string; (* /temperature/ *)
+  supported_operations : string list; (* [GET, POST, ...] *)
 }
 
 type component_type = {

--- a/fog05/json_objects/mec_app_definition.schema
+++ b/fog05/json_objects/mec_app_definition.schema
@@ -20,43 +20,9 @@
     "description": {
       "type": "string"
     },
-    "service_description": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "category": {
-            "type": "string"
-          },
-          "transports-supported": {
-            "type": "transport_description"
-          },
-          "serializers": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "version": {
-            "type": "string"
-          }
-        }
+    "service_info_type": {
+        <<<< HOW I express this as a service_info_type reference >>>>
     }
-    "transport_description": {
-        "type": "object",
-        "properties": {
-          "protocol": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "security": {
-            "type": "string"
-          }
-        }
-    },
     "components": {
       "type": "array",
       "items": {


### PR DESCRIPTION
I've organized the parameters a little according to the discussions on [last pull request](https://github.com/atolab/fog05/pull/15).

Now an entity can export the information of a service it provides, and all the necessary fields are located in the `service_info_type` field, which is reused for servicies that are dependencies of the `entity` defined.

Still left to know how we can reference this `service_info_type` (inside that type we refer the `transport_descriptor_type`) from the [mec_app_definition.schema](https://github.com/atolab/fog05/compare/master...MartinPJorge:master#diff-dd09922688ee2aab4eadbf06003fd172).